### PR TITLE
Separate build from release workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,12 +61,12 @@ jobs:
       - formatting
       - build
     runs-on: macos-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Check out
         uses: actions/checkout@v3
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: bundle/NTS Desktop-*.dmg
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,11 +52,7 @@ jobs:
         env:
           NODE_OPTIONS: --openssl-legacy-provider
       - name: Build Electron app
-        uses: samuelmeuli/action-electron-builder@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          release: false
-          args: --universal
+        run: make package
 
   release:
     name: Release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,11 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
       - name: Build Electron app
         run: make app
+      - name: Upload app
+        uses: actions/upload-artifact@v3
+        with:
+          name: app
+          path: bundle
 
   release:
     name: Release
@@ -65,6 +70,10 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v3
+      - name: Download app
+        uses: actions/download-artifact@v3
+        with:
+          name: app
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           NODE_OPTIONS: --openssl-legacy-provider
       - name: Build Electron app
-        run: make package
+        run: make app
 
   release:
     name: Release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,11 +35,8 @@ jobs:
       - name: Typecheck
         run: make formatting
 
-  release:
-    name: Release
-    needs:
-      - typecheck
-      - formatting
+  build:
+    name: Build
     runs-on: macos-latest
     steps:
       - name: Check out
@@ -60,6 +57,17 @@ jobs:
           github_token: ${{ secrets.github_token }}
           release: false
           args: --universal
+
+  release:
+    name: Release
+    needs:
+      - typecheck
+      - formatting
+      - build
+    runs-on: macos-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ packages: dist/yarn.lock
 main: index preload
 build: main client
 
-package: packages
+app: packages
 	@electron-builder build --mac --universal
 
 src/logo-menu.png: src/logo-menu.svg

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ main: index preload
 build: main client
 
 app: packages
-	@electron-builder build --mac --universal
+	@$(bin)/electron-builder build --mac --universal
 
 src/logo-menu.png: src/logo-menu.svg
 	inkscape -h 300 src/logo-menu.svg -o src/logo-menu.png

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require a restart to take effect.
 To build the application run:
 
 ```
-make build package
+make build app
 ```
 
 The app will now be in `bundle/mac-universal/NTS Desktop.app`.


### PR DESCRIPTION
- Separate build and release workflows from more parallelism.
- Use `package` make rule for building the app.